### PR TITLE
Add Better Support for multi-tsconfig projects (Like Veritas)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^20.12.7",
-    "@vitest/coverage-v8": "^1.5.1",
+    "@vitest/coverage-v8": "^1.5.2",
     "typescript": "^5.4.5",
-    "vitest": "^1.5.1"
+    "vitest": "^1.5.2"
   },
   "authors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@magik_io/lint_golem",
   "description": "A really magik lint golem",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "engines": {
-    "node": "v21.7.1",
-    "npm": "10.5.0"
+    "node": "v21.*.*",
+    "npm": "10.*.*"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,15 +241,12 @@ export class LintGolem {
     );
   }
 
-  public static async init(config: LintGolemOptions, verbose = false) {
+  public static async init(config: Omit<LintGolemOptions, 'tsconfigPaths'> & { tsconfigPaths?: Array<string> }, verbose = false) {
     const tsconfigPaths = await glob([
       `tsconfig.json`,
       `*.tsconfig.json`,
       ...(config.tsconfigPaths ?? []),
-    ], {
-      cwd: config.rootDir,
-      ignore: config.ignoreGlobs
-    });
+    ], { cwd: config.rootDir, ignore: config.ignoreGlobs });
     if (tsconfigPaths.length === 0) throw new Error('No tsconfig.json found', { cause: 'Missing projectRoot / glob failure' });
     if (verbose) console.info('Found tsconfigPaths:', tsconfigPaths.join(', \n'));
     return new LintGolem({ ...config, tsconfigPaths });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 import eslint from '@eslint/js';
 import plugin_n from 'eslint-plugin-n';
-import { sync as globSync } from 'fast-glob';
+import { glob } from 'fast-glob';
 import tseslint from 'typescript-eslint';
 import { LintGolemError } from './LintGolemError.js';
 
@@ -14,7 +14,7 @@ type DisabledRuleArray = Array<string>;
 interface LintGolemOptions {
   rootDir: string;
   ignoreGlobs?: string[];
-  projectRoots?: string[];
+  tsconfigPaths: string[];
   disableTypeCheckOn?: string[];
   disabledRules?: DisabledRuleArray;
   rules?: EslintModifiedRule;
@@ -48,11 +48,7 @@ export class LintGolem {
     '**/.yarn',
     '**/public/bundle/*',
   ];
-
-  public projectRoots: string[] = globSync([
-    `${this.rootDir}/tsconfig.json`,
-    `${this.rootDir}/*.tsconfig.json`,
-  ])
+  public tsconfigPaths: string[] = [];
 
   public disableTypeCheckOn: string[] = [
     '**/*.js',
@@ -133,10 +129,10 @@ export class LintGolem {
     }
   }
 
-  constructor({ rootDir, disableTypeCheckOn, ignoreGlobs, projectRoots, rules, disabledRules }: LintGolemOptions) {
+  constructor({ rootDir, disableTypeCheckOn, ignoreGlobs, tsconfigPaths, rules, disabledRules }: LintGolemOptions) {
     try {
       this.rootDir = rootDir ?? this.rootDir;
-      this.projectRoots = projectRoots ?? this.projectRoots;
+      this.tsconfigPaths = tsconfigPaths;
       if (ignoreGlobs) this.ignoreGlobs = [...this.ignoreGlobs, ...ignoreGlobs];
       if (disableTypeCheckOn) this.disableTypeCheckOn = [...this.disableTypeCheckOn, ...disableTypeCheckOn];
       if (rules && disabledRules) {
@@ -188,7 +184,7 @@ export class LintGolem {
       languageOptions: {
         ecmaVersion: 'latest',
         parserOptions: {
-          project: this.projectRoots,
+          project: this.tsconfigPaths,
           tsconfigRootDir: this.rootDir,
         }
       }
@@ -243,5 +239,19 @@ export class LintGolem {
       formatJSON(error.incomingRule),
       formatJSON(error.matchSource)
     );
+  }
+
+  public static async init(config: LintGolemOptions, verbose = false) {
+    const tsconfigPaths = await glob([
+      `tsconfig.json`,
+      `*.tsconfig.json`,
+      ...(config.tsconfigPaths ?? []),
+    ], {
+      cwd: config.rootDir,
+      ignore: config.ignoreGlobs
+    });
+    if (tsconfigPaths.length === 0) throw new Error('No tsconfig.json found', { cause: 'Missing projectRoot / glob failure' });
+    if (verbose) console.info('Found tsconfigPaths:', tsconfigPaths.join(', \n'));
+    return new LintGolem({ ...config, tsconfigPaths });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -379,13 +379,13 @@ __metadata:
     "@types/eslint": "npm:^8.56.10"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/node": "npm:^20.12.7"
-    "@vitest/coverage-v8": "npm:^1.5.1"
+    "@vitest/coverage-v8": "npm:^1.5.2"
     eslint: "npm:^9.1.1"
     eslint-plugin-n: "npm:^17.3.1"
     fast-glob: "npm:^3.3.2"
     typescript: "npm:^5.4.5"
     typescript-eslint: "npm:^7.7.1"
-    vitest: "npm:^1.5.1"
+    vitest: "npm:^1.5.2"
   peerDependencies:
     eslint: "*"
   languageName: unknown
@@ -738,9 +738,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/coverage-v8@npm:1.5.1"
+"@vitest/coverage-v8@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/coverage-v8@npm:1.5.2"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.1"
     "@bcoe/v8-coverage": "npm:^0.2.3"
@@ -756,62 +756,62 @@ __metadata:
     strip-literal: "npm:^2.0.0"
     test-exclude: "npm:^6.0.0"
   peerDependencies:
-    vitest: 1.5.1
-  checksum: 10c0/614b0a7ca024af243808e14deab98abad5a11b63102a9d2abe6f7647cefa11b5e4553e818344a75b7ecd9e9cd16a1872dbcd97e37b8ce7ba2af5ae5bd0438a48
+    vitest: 1.5.2
+  checksum: 10c0/cc982753969ca31033072324121288fc1945bc7ad09cc00ade9e2d29852acbfb97b177e7bfd0ab6c4cacab1e6600da1e287ed11e340745ffbe55d19212c25cc7
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/expect@npm:1.5.1"
+"@vitest/expect@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/expect@npm:1.5.2"
   dependencies:
-    "@vitest/spy": "npm:1.5.1"
-    "@vitest/utils": "npm:1.5.1"
+    "@vitest/spy": "npm:1.5.2"
+    "@vitest/utils": "npm:1.5.2"
     chai: "npm:^4.3.10"
-  checksum: 10c0/4743ca8de3ce269dca4aaf441a2a4d07510d341aeee7be59d17277c9a26b48c00541dd0570eb3d465f62290947135c8ef9978bc2697eadfbbd01cc7f0cdfdc37
+  checksum: 10c0/4e8400a55f9e2d4a5a5e2be8c5679fb0a3bfa7550085597b4022320bd9d8f70663707bb4ea02a5403b5327f405d7bc3de5dd21bbf43a8aabc6ceecfc83760ba8
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/runner@npm:1.5.1"
+"@vitest/runner@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/runner@npm:1.5.2"
   dependencies:
-    "@vitest/utils": "npm:1.5.1"
+    "@vitest/utils": "npm:1.5.2"
     p-limit: "npm:^5.0.0"
     pathe: "npm:^1.1.1"
-  checksum: 10c0/a079c111c9082360b471dbc1f46a82dc3521a768f2bba7a2036f24a7d0b27161ce8f922a553ac03c9e35b77a33d37b1bbbf9ff67eb4bd111c3a130028b513793
+  checksum: 10c0/9fc3e668817ceb49785a366959281eee31739b393b7629d19534a0f3044558663130275cf0631c1821cdf916b491bc3e8b57da1cfaeefa66a99473c08c4e7621
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/snapshot@npm:1.5.1"
+"@vitest/snapshot@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/snapshot@npm:1.5.2"
   dependencies:
     magic-string: "npm:^0.30.5"
     pathe: "npm:^1.1.1"
     pretty-format: "npm:^29.7.0"
-  checksum: 10c0/d3d769873b16297f6e9bc64c8394110ef981dc8f271f608270ee89d1a92e5515e56d9c2bede21fd3881baf919882652f9c912a435a6092147aafbc21d10f828d
+  checksum: 10c0/67ae235e59f1adec1e6a44e2a8ea1d2ee98f2416d3ccf566798474ee98943b87b3f20c2098e193866b01780ae4c767239e4f94dbbb3daf0f0978b8106e8e86b1
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/spy@npm:1.5.1"
+"@vitest/spy@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/spy@npm:1.5.2"
   dependencies:
     tinyspy: "npm:^2.2.0"
-  checksum: 10c0/865b94bc99a865c8adc813f25cc797b2f7ffdc7807ed54ce64f86125a8227ac80078b29c86d3463bb71febdddc582bd9f8d74f14c6089f088c1cd8af57691283
+  checksum: 10c0/d66de2873f762ba9a45ca03fe9d11db0c1910635e02289a5b54746c41bd68366b9d198b265e13a8608cc21774f4f197afb25acbba5c0769e651598df0eaab5b3
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:1.5.1":
-  version: 1.5.1
-  resolution: "@vitest/utils@npm:1.5.1"
+"@vitest/utils@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@vitest/utils@npm:1.5.2"
   dependencies:
     diff-sequences: "npm:^29.6.3"
     estree-walker: "npm:^3.0.3"
     loupe: "npm:^2.3.7"
     pretty-format: "npm:^29.7.0"
-  checksum: 10c0/45bef3c3c5505943f099937dadd28f8468a86220527f46de8b69c7cd581e7703f2b82831c331ea1dbd5bdf72b24d9ed4bb262343189352642d187b6f75e4e249
+  checksum: 10c0/019eeac016deb5d2434db4990b2ba1ebf37434a020c3d6bcf163c77af80e01dd9add7b3d379bdacd91497847026a5bd2aafe393035c48f5296ce5275bad00126
   languageName: node
   linkType: hard
 
@@ -3037,9 +3037,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-node@npm:1.5.1":
-  version: 1.5.1
-  resolution: "vite-node@npm:1.5.1"
+"vite-node@npm:1.5.2":
+  version: 1.5.2
+  resolution: "vite-node@npm:1.5.2"
   dependencies:
     cac: "npm:^6.7.14"
     debug: "npm:^4.3.4"
@@ -3048,7 +3048,7 @@ __metadata:
     vite: "npm:^5.0.0"
   bin:
     vite-node: vite-node.mjs
-  checksum: 10c0/d3591d9c30fd949ec590183ff234c114b9a676349cc54a83c2ee9eec449ab77aa45302aa9465d5a849d83d4d76721755634e030582289033f2ef5a74b4890929
+  checksum: 10c0/a5e90ae2b3ec912fbdf22ecf10f1b0d769e2fd1f24c5e4090488be03068b994dbcf9bea492d5c5fbde77f45a0e328e90a48a9ecdcb5eab30709e6d221aa0c7bd
   languageName: node
   linkType: hard
 
@@ -3092,15 +3092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitest@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "vitest@npm:1.5.1"
+"vitest@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "vitest@npm:1.5.2"
   dependencies:
-    "@vitest/expect": "npm:1.5.1"
-    "@vitest/runner": "npm:1.5.1"
-    "@vitest/snapshot": "npm:1.5.1"
-    "@vitest/spy": "npm:1.5.1"
-    "@vitest/utils": "npm:1.5.1"
+    "@vitest/expect": "npm:1.5.2"
+    "@vitest/runner": "npm:1.5.2"
+    "@vitest/snapshot": "npm:1.5.2"
+    "@vitest/spy": "npm:1.5.2"
+    "@vitest/utils": "npm:1.5.2"
     acorn-walk: "npm:^8.3.2"
     chai: "npm:^4.3.10"
     debug: "npm:^4.3.4"
@@ -3114,13 +3114,13 @@ __metadata:
     tinybench: "npm:^2.5.1"
     tinypool: "npm:^0.8.3"
     vite: "npm:^5.0.0"
-    vite-node: "npm:1.5.1"
+    vite-node: "npm:1.5.2"
     why-is-node-running: "npm:^2.2.2"
   peerDependencies:
     "@edge-runtime/vm": "*"
     "@types/node": ^18.0.0 || >=20.0.0
-    "@vitest/browser": 1.5.1
-    "@vitest/ui": 1.5.1
+    "@vitest/browser": 1.5.2
+    "@vitest/ui": 1.5.2
     happy-dom: "*"
     jsdom: "*"
   peerDependenciesMeta:
@@ -3138,7 +3138,7 @@ __metadata:
       optional: true
   bin:
     vitest: vitest.mjs
-  checksum: 10c0/85f6b9250ca370b4ddc3daef5431b82d8d8cb4f64f04b7d8b53f9fad9bd93d2771ddf561d5e0b3a078b666e7d9dbdc9826e43968d58fc14c894ce7c6de2d665f
+  checksum: 10c0/1ad3a33d3ab5faeb4baa9c9ba62b34e94c00a6e140ba2a8589224d6b9db89e3a3d6753d1d1ecb85cbcb0f9023b22d8066dfde7f31e1733484f2ea5cf640f4969
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Noticed that a change I'd made accidentally stopped our linting on the frontend, which revealed it wasn't correctly seeing all our TSconfigs. This should fix that, additional test to support that