### PR TITLE
Improve Code Quality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
+      - name: "Sanitize branch name"
+        id: sanitize
+        run: echo "branch=$(echo '${{ matrix.branch }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
       - name: "Install pnpm"
         uses: pnpm/action-setup@v4
         with:
@@ -36,7 +39,7 @@ jobs:
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.branch && replace(matrix.branch, '/', '-') || 'unknown' }}
+          name: coverage-${{ steps.sanitize.outputs.branch }}
           path: coverage
 
   report-coverage:
@@ -48,10 +51,13 @@ jobs:
       # Required to put a comment into the pull-request
       pull-requests: write
     steps:
+      - name: "Sanitize branch name"
+        id: sanitize
+        run: echo "branch=$(echo '${{ github.head_ref }}' | sed 's/\//-/g')" >> $GITHUB_OUTPUT
       - name: "Download Coverage Artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ github.head_ref && replace(github.head_ref, '/', '-') || 'unknown' }}
+          name: coverage-${{ steps.sanitize.outputs.branch }}
           path: coverage
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Upload Coverage"
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.branch }}
+          name: coverage-${{ matrix.branch && replace(matrix.branch, '/', '-') || 'unknown' }}
           path: coverage
 
   report-coverage:
@@ -51,7 +51,7 @@ jobs:
       - name: "Download Coverage Artifacts"
         uses: actions/download-artifact@v4
         with:
-          name: coverage-${{ github.head_ref }}
+          name: coverage-${{ github.head_ref && replace(github.head_ref, '/', '-') || 'unknown' }}
           path: coverage
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
GitHub Actions artifact names cannot contain forward slashes. Updated the test workflow to replace '/' with '-' in branch names when creating and downloading coverage artifacts.