### PR TITLE
refactor: Major code quality improvements and bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.5.0",
   "sideEffects": false,
   "engines": {
-    "node": "25"
+    "node": ">=25"
   },
   "packageManager": "pnpm@10.22.0",
   "exports": {
@@ -62,10 +62,6 @@
     "type": "git",
     "url": "https://github.com/MagikIO/lint_golem.git"
   },
-  "browserslist": [
-    "last 2 version",
-    "> 1%"
-  ],
   "license": "MIT",
   "unbuild": {
     "rollup": {

--- a/src/LintGolemError.ts
+++ b/src/LintGolemError.ts
@@ -1,6 +1,5 @@
 type PluginPrefixes = 'n/' | '@typescript-eslint/';
 type EslintOption = Record<string, boolean | string | Array<unknown>>;
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 type EslintModifiedRule = Record<string | `${PluginPrefixes}string`, [action: 'off' | 'error' | 'warn', ...Array<string | EslintOption>]>;
 
 export class LintGolemError extends Error {


### PR DESCRIPTION
- Change Node engine constraint to >=25
- Fix critical rule assignment bugs where entire rules object was assigned instead of filtered rules
- Fix disabled rules merging to properly append instead of replace
- Remove duplicate @typescript-eslint/no-var-requires from disabled rules list
- Remove browserslist config (not applicable for Node.js package)
- Replace console.info with proper LintGolemError throwing in init() method
- Refactor to use static readonly constants for all default rules
- Make all instance properties readonly to reduce mutable state
- Add comprehensive validation:
  - Validate rootDir exists and is a directory
  - Validate all tsconfigPaths files exist
  - Validate ecmaVersion values
- Add new validation tests
- Update test suite to use real paths instead of fake paths
- Remove unused eslint-disable directives

All tests passing (23 tests, 90.9% coverage)
All linting and type-checking passing